### PR TITLE
Improved version, hopefully more reliable

### DIFF
--- a/rmsigchks_t8015.py
+++ b/rmsigchks_t8015.py
@@ -11,6 +11,33 @@ DEVICE2HOST = 0xA1
 DFU_DNLOAD = 1
 DFU_ABORT = 4
 
+
+REMAP_PAGE  = 0x000000010000c000 #heapcheck
+REMAP_PAGE2 = 0x0000000100004000 #sigcheck
+
+SRAM_PAGETABLE_PAGE = 0x0000000180014000 #works
+
+SRAM_REMAP_PAGE  = 0x00000001801f8000
+SRAM_REMAP_PAGE2 = 0x00000001801f4000
+
+PAGE_SIZE = 0x4000
+
+def makePTE_Page_16K(addr):
+    addr >>= 14
+    e = 0b11            #valid and isPage
+    e |= 1      << 2    #attrIndex 1
+    e |= 0b10   << 6    #AP R- in EL1, -- in EL0
+    e |= 1      << 10   #AF
+    e |= addr   << 14   #outputAddress
+    return e
+
+def makePTE_Table_16K(addr):
+    addr >>= 14
+    e = 0b11            #valid and isTable
+    e |= addr   << 14   #outputAddress
+    return e
+
+
 def main():
     print "*** SecureROM t8015 sigcheckpath by tihmstar ***"
     device = dfu.acquire_device()
@@ -25,16 +52,40 @@ def main():
 
     device = usbexec.PwnedUSBDevice()
 
-    device.write_memory(0x000000018000c400,binascii.unhexlify("2506000001000000")) #clear write bit
-    device.execute(0,0x1000004F0) #memory barrier
-    device.execute(0,0x1000004AC) #flush tlb
+    #make Level3 Table
+    l3table = ""
+    for addr in range(0x0000000100000000,0x0000000100100000,PAGE_SIZE):
+        entry = struct.pack("<Q",makePTE_Page_16K(addr))
+        if addr == REMAP_PAGE: #we are remapping heapcheck page
+            entry = struct.pack("<Q",makePTE_Page_16K(SRAM_REMAP_PAGE))
+        elif addr == REMAP_PAGE2: #we are remapping sigcheck page
+            entry = struct.pack("<Q",makePTE_Page_16K(SRAM_REMAP_PAGE2))
+        l3table += entry
+
+    #we write L3 Table here
+    device.write_memory(SRAM_PAGETABLE_PAGE,l3table)
+
+    #remap heapcheck page to sram
+    device.memcpy(SRAM_REMAP_PAGE,REMAP_PAGE,PAGE_SIZE)
+
+    #remap sigcheck page to sram
+    device.memcpy(SRAM_REMAP_PAGE2,REMAP_PAGE2,PAGE_SIZE)
+
+    # patch heap corruption check
+    device.write_memory(0x000000010000db98-REMAP_PAGE+SRAM_REMAP_PAGE,"\xC0\x03\x5F\xD6")
 
     #patch codesigs
-    device.write_memory(0x000000010000624c,"\x00\x00\x80\xD2") #patch sigcheck
+    device.write_memory(0x000000010000624c-REMAP_PAGE2+SRAM_REMAP_PAGE2,"\x00\x00\x80\xD2")
 
-    device.write_memory(0x000000010000db98,"\xC0\x03\x5F\xD6") #disable heap corruption check
+    #L2 Table point to L3
+    device.write_memory(0x000000018000c400,struct.pack("<Q",makePTE_Table_16K(SRAM_PAGETABLE_PAGE)))
 
-    device.execute(0,0x1000004F0) #memory barrier
+    #memory barrier
+    device.execute(0,0x1000004F0)
+
+    #flush tlb
+    device.execute(0,0x1000004AC)
+
 
     print("done remapping and patching page")
     device = dfu.acquire_device()


### PR DESCRIPTION
When running this forks version of ipwndfu, the device is in a state where we can read, write memory and execute code.
Furthermore wxn is disabled.
However to do sigpatches we still have the issue of ROM being not writable.

In my previous version i simply modified the pagetables and added write permissions to the existing rom mapping.
Then (as far as the MMU is concerned) the virtual addresses are writable.
But wait a sec, how is it possible to write to ROM, afterall it's ReadOnlyMemory?
Well, when the MMU is turned on, you also turn on cacheing, otherwise each memory access is painfully slow.
When writing to memory, you're also writing to CPU caches L1, L2, L3 and (depending on your cache policy) 
either directly to the main memory (write through policy), or the write is postponed until the cacheline is evicted from cache (write back policy).
So when mapping ROM writable and writing to it, we aren't actually writing to the ROM itself, but only to the CPU caches.

Now there are 2 issues we can run into with this method:
1) Assuming that performing an actual write request to ROM causes some kind of fault, the device might crash once that happens.
Assuming the cache is set up to be write-back (i didn't check what is actually used), then we're fine until the cacheline is evicted and an actual write to main
memory is performed. Now the ROM is mostly deterministic, but not fully deterministic. 
This means that if this is true, the method might work sometimes and sometimes we'll run into crashes (after extensively using the method, i indeed run into unrealiability issues).
If write-through policy is used, we would crash right away assuming a write to ROM does cause a crash.
Conclusion: We either have write-back cache policy, or a write to ROM does not cause a crash.

2) Even when a write to ROM does not cause a fault right away, we still have a problem in case the cachelines containing the patches are evicted from cache.
Because when the memory is fetched then, it will load the unmodified copy from ROM, rather our patched version.
Since the exploit does trash the heap, the device will panic when it reaches the heap corruption check before booting the next image.
Because there aren't any information about caching (how large the caches are etc), it's hard to tell which one of these is more likely the real issue.
However relying on patches to persist in CPU caches is non-ideal anyways.


There is a more obvious solution to the problem.
Rather than relying on the patches to stay alive in CPU caches, we can simply remap the pages in question and patch them in SRAM.
This is what i implemented here.
We need to apply 2 patches, which is: disabling the heap corruption check before jumping into the next image and disabling signature checks.
This will occupy 2 fully pages in SRAM (2*0x4000=0x8000) as well as some more space to set up another level of pagetables.
BootROM sets up just 2 Level page tables, but only uses the upper one to make block mappings of (if i'm not mistaken) 2MB.
One for the ROM, one for RAM and a couple others for device memory.
In order to do that we redicret the Level2 entry to a Level3 entry that we create and place in some unused memory, we only need to have enough page table entries to map the rom pages that are used, thus we don't need a full page here. It's fine if the page contains other data which are invalid page table entries, as long as BootROM doesn't access them.
The rest is easy: point L2 Table entry responsible for ROM to L3 Table which we create, in the L3 Table remap 2 pages to some unused pages at the end of SRAM.
Now since we have 2 mappings we don't even need to bother about wxn, since we can write to the SRAM by its *true* address and execute it with the ROM address.

This version should be more robust. Of course i only tested it twice, so i can't tell for sure. But i do believe it does :)
Be a believer too and merge this ;)